### PR TITLE
Defaulting 2 Item class variables to None to support other use cases

### DIFF
--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -213,6 +213,8 @@ class Item(BaseRecord):
     def metadata_from_csv_row(cls, row, field_map):
         """Create metadata for an item based on a CSV row and a JSON mapping field map."""
         metadata = []
+        file_identifier = None
+        source_system_identifier = None
         for f in field_map:
             field = row[field_map[f]["csv_field_name"]]
             if f == "file_identifier":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,20 @@ def aspace_mapping():
 
 
 @pytest.fixture()
+def mapping_no_file_identifier():
+    with open("tests/fixtures/mapping_no_file_identifier.json") as f:
+        mapping = json.load(f)
+        yield mapping
+
+
+@pytest.fixture()
+def mapping_no_source_system_identifier():
+    with open("tests/fixtures/mapping_no_source_system_identifier.json") as f:
+        mapping = json.load(f)
+        yield mapping
+
+
+@pytest.fixture()
 def output_dir(tmp_path):
     output_dir = tmp_path / "output"
     output_dir.mkdir()

--- a/tests/fixtures/mapping_no_file_identifier.json
+++ b/tests/fixtures/mapping_no_file_identifier.json
@@ -1,0 +1,32 @@
+{
+  "dc.title": {
+    "csv_field_name": "title",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "source_system_identifier": {
+    "csv_field_name": "uri",
+    "language": null,
+    "delimiter": ""
+  },
+  "dc.contributor.author": {
+    "csv_field_name": "author",
+    "language": null,
+    "delimiter": "|"
+  },
+  "dc.description": {
+    "csv_field_name": "description",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights": {
+    "csv_field_name": "rights_statement",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights.uri": {
+    "csv_field_name": "rights_uri",
+    "language": null,
+    "delimiter": ""
+  }
+}

--- a/tests/fixtures/mapping_no_source_system_identifier.json
+++ b/tests/fixtures/mapping_no_source_system_identifier.json
@@ -1,0 +1,32 @@
+{
+  "file_identifier": {
+    "csv_field_name": "file_identifier",
+    "language": null,
+    "delimiter": ""
+  },
+  "dc.title": {
+    "csv_field_name": "title",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.contributor.author": {
+    "csv_field_name": "author",
+    "language": null,
+    "delimiter": "|"
+  },
+  "dc.description": {
+    "csv_field_name": "description",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights": {
+    "csv_field_name": "rights_statement",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights.uri": {
+    "csv_field_name": "rights_uri",
+    "language": null,
+    "delimiter": ""
+  }
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,9 +122,49 @@ def test_item_bitstreams_in_directory(input_dir):
     assert item.bitstreams[1].name == "test_02.pdf"
 
 
-def test_item_metadata_from_csv_row(aspace_delimited_csv, aspace_mapping):
+def test_item_metadata_from_csv_row_aspace_mapping(
+    aspace_delimited_csv, aspace_mapping
+):
     row = next(aspace_delimited_csv)
     item = models.Item.metadata_from_csv_row(row, aspace_mapping)
+    assert attr.asdict(item)["metadata"] == [
+        {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
+        {"key": "dc.contributor.author", "value": "Smith, John", "language": None},
+        {"key": "dc.contributor.author", "value": "Smith, Jane", "language": None},
+        {
+            "key": "dc.description",
+            "value": "More info at /repo/0/ao/456",
+            "language": "en_US",
+        },
+        {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
+        {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
+    ]
+
+
+def test_item_metadata_from_csv_row_no_file_identifier(
+    aspace_delimited_csv, mapping_no_file_identifier
+):
+    row = next(aspace_delimited_csv)
+    item = models.Item.metadata_from_csv_row(row, mapping_no_file_identifier)
+    assert attr.asdict(item)["metadata"] == [
+        {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
+        {"key": "dc.contributor.author", "value": "Smith, John", "language": None},
+        {"key": "dc.contributor.author", "value": "Smith, Jane", "language": None},
+        {
+            "key": "dc.description",
+            "value": "More info at /repo/0/ao/456",
+            "language": "en_US",
+        },
+        {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
+        {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
+    ]
+
+
+def test_item_metadata_from_csv_row_no_source_system_identifier(
+    aspace_delimited_csv, mapping_no_source_system_identifier
+):
+    row = next(aspace_delimited_csv)
+    item = models.Item.metadata_from_csv_row(row, mapping_no_source_system_identifier)
     assert attr.asdict(item)["metadata"] == [
         {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
         {"key": "dc.contributor.author", "value": "Smith, John", "language": None},


### PR DESCRIPTION
#### What does this PR do?
* Set `file_identifier` and `source_system_identifier` to `None` in `Item.metadata_from_csv_row` method so Item metadata can be created without them
* Add test fixtures and unit tests for items without those 2 variables

#### Helpful background context
Carl was testing the library and the discussion made it clear that `file_identifier` and `source_system_identifier` were required to use the `Item.metadata_from_csv_row` method. As we are considering more general usage of this library, this type of logic should be stripped because it is too closely tied to local workflows. Let me know if there is a better way of handling this

#### How can a reviewer manually see the effects of these changes?
Run the update unit tests with `pipenv run pytest` which now account for both these variables missing

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
