### PR TITLE
Shift Client methods to appropriate record classes

### DIFF
--- a/dsaps/cli.py
+++ b/dsaps/cli.py
@@ -175,7 +175,10 @@ def newcollection(ctx, community_handle, collection_name):
     with the additems CLI command to populate the new collection with
     items."""
     client = ctx.obj["client"]
-    collection_uuid = client.post_coll_to_comm(community_handle, collection_name)
+    collection = Collection()
+    collection_uuid = collection.post_to_community(
+        client, community_handle, collection_name
+    )
     ctx.obj["collection_uuid"] = collection_uuid
 
 

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -38,12 +38,6 @@ class Client:
         self.header = header
         logger.info(f"Authenticated to {self.url} as " f"{self.user_full_name}")
 
-    def delete_record(self, uuid, record_type):
-        """Delete record based on specified UUID and record type."""
-        endpoint = f"{self.url}/{record_type}/{uuid}"
-        response = requests.delete(endpoint, headers=self.header, cookies=self.cookies)
-        return response.status_code
-
     def filtered_item_search(self, key, string, query_type, selected_collections=""):
         """Perform a search against the filtered items endpoint."""
         offset = 0
@@ -103,8 +97,8 @@ class Client:
         response = requests.post(
             endpoint, headers=header_upload, cookies=self.cookies, data=data
         ).json()
-        bitstream_uuid = response["uuid"]
-        return bitstream_uuid
+        bitstream.uuid = response["uuid"]
+        return bitstream.uuid
 
     def post_coll_to_comm(self, comm_handle, coll_name):
         """Post a collection to a specified community."""
@@ -215,6 +209,14 @@ class Item(BaseRecord):
         ]
         self.bitstreams.sort(key=lambda x: x.name)
 
+    def delete(self, client):
+        """Delete item."""
+        endpoint = f"{client.url}/items/{self.uuid}"
+        response = requests.delete(
+            endpoint, headers=client.header, cookies=client.cookies
+        )
+        return response.status_code
+
     @classmethod
     def metadata_from_csv_row(cls, row, field_map):
         """Create metadata for an item based on a CSV row and a JSON mapping field map."""
@@ -247,9 +249,17 @@ class Item(BaseRecord):
 
 
 @attr.s
-class Bitstream:
+class Bitstream(BaseRecord):
     name = Field()
     file_path = Field()
+
+    def delete(self, client):
+        """Delete bitstream."""
+        endpoint = f"{client.url}/bitstreams/{self.uuid}"
+        response = requests.delete(
+            endpoint, headers=client.header, cookies=client.cookies
+        )
+        return response.status_code
 
 
 @attr.s

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -38,6 +38,12 @@ class Client:
         self.header = header
         logger.info(f"Authenticated to {self.url} as " f"{self.user_full_name}")
 
+    def delete_record(self, uuid, record_type):
+        """Delete record based on specified UUID and record type."""
+        endpoint = f"{self.url}/{record_type}/{uuid}"
+        response = requests.delete(endpoint, headers=self.header, cookies=self.cookies)
+        return response.status_code
+
     def filtered_item_search(self, key, string, query_type, selected_collections=""):
         """Perform a search against the filtered items endpoint."""
         offset = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,8 +67,8 @@ def web_mock():
         m.post("mock://example.com/login", cookies=cookies)
         user_json = {"fullname": "User Name"}
         m.get("mock://example.com/status", json=user_json)
-        rec_json = {"metadata": {"title": "Sample title"}, "type": "item"}
-        m.get("mock://example.com/items/123?expand=all", json=rec_json)
+        item_metadata_json = {"metadata": {"title": "Sample title"}, "type": "item"}
+        m.get("mock://example.com/items/123?expand=all", json=item_metadata_json)
         results_json1 = {"items": [{"link": "1234"}]}
         results_json2 = {"items": []}
         m.get(
@@ -77,19 +77,20 @@ def web_mock():
         )
         rec_json = {"uuid": "a1b2"}
         m.get("mock://example.com/handle/111.1111", json=rec_json)
-        coll_json = {"uuid": "c3d4"}
-        m.post("mock://example.com/communities/a1b2/collections", json=coll_json)
+        collection_json = {"uuid": "c3d4"}
+        m.post("mock://example.com/communities/a1b2/collections", json=collection_json)
         item_json = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/c3d4/items", json=item_json)
-        b_json_1 = {"uuid": "g7h8"}
+        bitstream_json_1 = {"uuid": "g7h8"}
         url_1 = "mock://example.com/items/e5f6/bitstreams?name=test_01.pdf"
-        m.post(url_1, json=b_json_1)
-        b_json_2 = {"uuid": "i9j0"}
+        m.post(url_1, json=bitstream_json_1)
+        bitstream_json_2 = {"uuid": "i9j0"}
         url_2 = "mock://example.com/items/e5f6/bitstreams?name=test_02.pdf"
-        m.post(url_2, json=b_json_2)
+        m.post(url_2, json=bitstream_json_2)
         m.get("mock://remoteserver.com/files/test_01.pdf", content=b"Sample")
-        coll_json = {"uuid": "k1l2"}
-        m.get("mock://example.com/handle/333.3333", json=coll_json)
+        collection_json = {"uuid": "k1l2"}
+        m.get("mock://example.com/handle/333.3333", json=collection_json)
         item_json_2 = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/k1l2/items", json=item_json_2)
+        m.delete("mock://example.com/items/g7h8", status_code=200)
         yield m

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,5 +92,6 @@ def web_mock():
         m.get("mock://example.com/handle/333.3333", json=collection_json)
         item_json_2 = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/k1l2/items", json=item_json_2)
-        m.delete("mock://example.com/items/g7h8", status_code=200)
+        m.delete("mock://example.com/items/m3n4", status_code=200)
+        m.delete("mock://example.com/bitstreams/o5p6", status_code=200)
         yield m

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,12 +12,6 @@ def test_authenticate(client):
     assert client.cookies == {"JSESSIONID": "11111111"}
 
 
-def test_delete_record(client):
-    """Test delete_record method."""
-    response = client.delete_record("g7h8", "items")
-    assert response == 200
-
-
 def test_filtered_item_search(client):
     """Test filtered_item_search method."""
     key = "dc.title"
@@ -115,6 +109,12 @@ def test_collection_post_items(client, input_dir, aspace_delimited_csv, aspace_m
         assert item.uuid == "e5f6"
 
 
+def test_item_delete(client):
+    item = models.Item(uuid="m3n4")
+    response = item.delete(client)
+    assert response == 200
+
+
 def test_item_bitstreams_in_directory(input_dir):
     item = models.Item(file_identifier="test")
     item.bitstreams_in_directory(input_dir)
@@ -143,3 +143,9 @@ def test_item_metadata_from_csv_row(aspace_delimited_csv, aspace_mapping):
         {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
         {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
     ]
+
+
+def test_bitstream_delete(client):
+    bitstream = models.Bitstream(uuid="o5p6")
+    response = bitstream.delete(client)
+    assert response == 200

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,25 +35,16 @@ def test_get_record(client):
     assert attr.asdict(rec_obj)["metadata"] == {"title": "Sample title"}
 
 
-def test_post_bitstream(client, input_dir):
-    """Test post_bitstream method."""
-    item_uuid = "e5f6"
-    bitstream = models.Bitstream(
-        name="test_01.pdf", file_path=f"{input_dir}test_01.pdf"
-    )
-    bit_uuid = client.post_bitstream(item_uuid, bitstream)
-    assert bit_uuid == "g7h8"
-
-
-def test_post_coll_to_comm(client):
-    """Test post_coll_to_comm method."""
-    comm_handle = "111.1111"
+def test_collection_post_to_community(client):
+    """Test post_coll_to_community method."""
+    collection = models.Collection()
+    community_handle = "111.1111"
     coll_name = "Test Collection"
-    coll_uuid = client.post_coll_to_comm(comm_handle, coll_name)
+    coll_uuid = collection.post_to_community(client, community_handle, coll_name)
     assert coll_uuid == "c3d4"
 
 
-def test_post_item_to_collection(client, input_dir):
+def test_item_post_to_collection(client, input_dir):
     """Test post_item_to_collection method."""
     item = models.Item()
     item.bitstreams = [
@@ -67,7 +58,7 @@ def test_post_item_to_collection(client, input_dir):
         models.MetadataEntry(key="dc.relation.isversionof", value="repo/0/ao/123"),
     ]
     coll_uuid = "c3d4"
-    item_uuid, item_handle = client.post_item_to_collection(coll_uuid, item)
+    item_uuid, item_handle = item.post_to_collection(client, coll_uuid, item)
     assert item_uuid == "e5f6"
     assert item_handle == "222.2222"
 
@@ -149,3 +140,13 @@ def test_bitstream_delete(client):
     bitstream = models.Bitstream(uuid="o5p6")
     response = bitstream.delete(client)
     assert response == 200
+
+
+def test_bitstream_post_to_item(client, input_dir):
+    """Test post_bitstream method."""
+    item_uuid = "e5f6"
+    bitstream = models.Bitstream(
+        name="test_01.pdf", file_path=f"{input_dir}test_01.pdf"
+    )
+    bit_uuid = bitstream.post_bitstream(client, item_uuid, bitstream)
+    assert bit_uuid == "g7h8"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,12 @@ def test_authenticate(client):
     assert client.cookies == {"JSESSIONID": "11111111"}
 
 
+def test_delete_record(client):
+    """Test delete_record method."""
+    response = client.delete_record("g7h8", "items")
+    assert response == 200
+
+
 def test_filtered_item_search(client):
     """Test filtered_item_search method."""
     key = "dc.title"


### PR DESCRIPTION
Draft, will rebase after #28 is merged

#### What does this PR do?
* Shift `post_bitstream` to Bitstream class and rename
* Shift `post_to_coll` to Collection class and rename
* Shift `post_item_to_collection` to Item class and rename
* Minor updates to the methods to ensure proper functionality in new location
* Minor updates to `newcollection` CLI command to reflect the shift

#### Helpful background context
Based on Slack discussion with Helen about the appropriate location for these methods.

#### How can a reviewer manually see the effects of these changes?
Verify that unit tests still pass when running `pipenv run pytest`

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
