### PR TITLE
Expanded testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Option (short) | Option (long)             | Description
 -d | --content-directory | The full path to the content, either a directory of files or a URL for the storage location.
 -t | --file-type | The file type to be uploaded, if limited to one file type.
 -r | --ingest-report| Create ingest report for updating other systems.
+-o | --output-directory | The path of the output files, include / at the end of the path.
 -c | --collection-handle | The handle of the collection to which items are being added.
 
 

--- a/dsaps/cli.py
+++ b/dsaps/cli.py
@@ -175,7 +175,10 @@ def newcollection(ctx, community_handle, collection_name):
     with the additems CLI command to populate the new collection with
     items."""
     client = ctx.obj["client"]
-    collection_uuid = client.post_coll_to_comm(community_handle, collection_name)
+    collection = Collection()
+    collection_uuid = collection.post_to_community(
+        client, community_handle, collection_name
+    )
     ctx.obj["collection_uuid"] = collection_uuid
 
 

--- a/dsaps/helpers.py
+++ b/dsaps/helpers.py
@@ -19,10 +19,10 @@ def create_file_list(file_path, file_type):
     return file_list
 
 
-def create_ingest_report(items, file_name):
+def create_ingest_report(items, file_name, output_directory):
     """Create ingest report that matches external systems' identifiers with newly
     created DSpace handles."""
-    with open(f"{file_name}", "w") as writecsv:
+    with open(f"{output_directory}{file_name}", "w") as writecsv:
         writer = csv.writer(writecsv)
         writer.writerow(["uri", "link"])
         for item in items:

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -38,12 +38,6 @@ class Client:
         self.header = header
         logger.info(f"Authenticated to {self.url} as " f"{self.user_full_name}")
 
-    def delete_record(self, uuid, record_type):
-        """Delete record based on specified UUID and record type."""
-        endpoint = f"{self.url}/{record_type}/{uuid}"
-        response = requests.delete(endpoint, headers=self.header, cookies=self.cookies)
-        return response.status_code
-
     def filtered_item_search(self, key, string, query_type, selected_collections=""):
         """Perform a search against the filtered items endpoint."""
         offset = 0
@@ -103,8 +97,8 @@ class Client:
         response = requests.post(
             endpoint, headers=header_upload, cookies=self.cookies, data=data
         ).json()
-        bitstream_uuid = response["uuid"]
-        return bitstream_uuid
+        bitstream.uuid = response["uuid"]
+        return bitstream.uuid
 
     def post_coll_to_comm(self, comm_handle, coll_name):
         """Post a collection to a specified community."""
@@ -215,6 +209,14 @@ class Item(BaseRecord):
         ]
         self.bitstreams.sort(key=lambda x: x.name)
 
+    def delete(self, client):
+        """Delete item."""
+        endpoint = f"{client.url}/items/{self.uuid}"
+        response = requests.delete(
+            endpoint, headers=client.header, cookies=client.cookies
+        )
+        return response.status_code
+
     @classmethod
     def metadata_from_csv_row(cls, row, field_map):
         """Create metadata for an item based on a CSV row and a JSON mapping field map."""
@@ -249,9 +251,17 @@ class Item(BaseRecord):
 
 
 @attr.s
-class Bitstream:
+class Bitstream(BaseRecord):
     name = Field()
     file_path = Field()
+
+    def delete(self, client):
+        """Delete bitstream."""
+        endpoint = f"{client.url}/bitstreams/{self.uuid}"
+        response = requests.delete(
+            endpoint, headers=client.header, cookies=client.cookies
+        )
+        return response.status_code
 
 
 @attr.s

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -213,6 +213,8 @@ class Item(BaseRecord):
     def metadata_from_csv_row(cls, row, field_map):
         """Create metadata for an item based on a CSV row and a JSON mapping field map."""
         metadata = []
+        file_identifier = None
+        source_system_identifier = None
         for f in field_map:
             field = row[field_map[f]["csv_field_name"]]
             if f == "file_identifier":

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -38,6 +38,12 @@ class Client:
         self.header = header
         logger.info(f"Authenticated to {self.url} as " f"{self.user_full_name}")
 
+    def delete_record(self, uuid, record_type):
+        """Delete record based on specified UUID and record type."""
+        endpoint = f"{self.url}/{record_type}/{uuid}"
+        response = requests.delete(endpoint, headers=self.header, cookies=self.cookies)
+        return response.status_code
+
     def filtered_item_search(self, key, string, query_type, selected_collections=""):
         """Perform a search against the filtered items endpoint."""
         offset = 0

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -88,26 +88,26 @@ class Client:
             exit()
         return rec_obj
 
-    def _populate_class_instance(self, class_type, rec_obj):
-        """Populate class instance with data from record."""
-        fields = [op(field) for field in attr.fields(class_type)]
-        kwargs = {k: v for k, v in rec_obj.items() if k in fields}
-        kwargs["objtype"] = rec_obj["type"]
-        if class_type == Community:
-            collections = self._build_uuid_list(rec_obj, kwargs, "collections")
-            rec_obj["collections"] = collections
-        elif class_type == Collection:
-            items = self._build_uuid_list(rec_obj, "items")
-            rec_obj["items"] = items
-        rec_obj = class_type(**kwargs)
-        return rec_obj
-
     def _build_uuid_list(self, rec_obj, children):
         """Build list of the uuids of the object's children."""
         child_list = []
         for child in rec_obj[children]:
             child_list.append(child["uuid"])
         return child_list
+
+    def _populate_class_instance(self, class_type, rec_obj):
+        """Populate class instance with data from record."""
+        fields = [op(field) for field in attr.fields(class_type)]
+        kwargs = {k: v for k, v in rec_obj.items() if k in fields}
+        kwargs["objtype"] = rec_obj["type"]
+        if class_type == Community:
+            collections = self._build_uuid_list(rec_obj, "collections")
+            rec_obj["collections"] = collections
+        elif class_type == Collection:
+            items = self._build_uuid_list(rec_obj, "items")
+            rec_obj["items"] = items
+        rec_obj = class_type(**kwargs)
+        return rec_obj
 
 
 @attr.s

--- a/dsaps/models.py
+++ b/dsaps/models.py
@@ -88,49 +88,6 @@ class Client:
             exit()
         return rec_obj
 
-    def post_bitstream(self, item_uuid, bitstream):
-        """Post a bitstream to a specified item and return the bitstream
-        ID."""
-        endpoint = f"{self.url}/items/{item_uuid}" f"/bitstreams?name={bitstream.name}"
-        header_upload = {"accept": "application/json"}
-        data = open(bitstream.file_path, "rb")
-        response = requests.post(
-            endpoint, headers=header_upload, cookies=self.cookies, data=data
-        ).json()
-        bitstream.uuid = response["uuid"]
-        return bitstream.uuid
-
-    def post_coll_to_comm(self, comm_handle, coll_name):
-        """Post a collection to a specified community."""
-        hdl_endpoint = f"{self.url}/handle/{comm_handle}"
-        community = requests.get(
-            hdl_endpoint, headers=self.header, cookies=self.cookies
-        ).json()
-        comm_uuid = community["uuid"]
-        uuid_endpoint = f"{self.url}/communities/{comm_uuid}/collections"
-        coll_uuid = requests.post(
-            uuid_endpoint,
-            headers=self.header,
-            cookies=self.cookies,
-            json={"name": coll_name},
-        ).json()
-        coll_uuid = coll_uuid["uuid"]
-        logger.info(f"Collection posted: {coll_uuid}")
-        return coll_uuid
-
-    def post_item_to_collection(self, collection_uuid, item):
-        """Post item to a specified collection and return the item ID."""
-        endpoint = f"{self.url}/collections/{collection_uuid}/items"
-        post_response = requests.post(
-            endpoint,
-            headers=self.header,
-            cookies=self.cookies,
-            json={"metadata": attr.asdict(item)["metadata"]},
-        ).json()
-        item_uuid = post_response["uuid"]
-        item_handle = post_response["handle"]
-        return item_uuid, item_handle
-
     def _populate_class_instance(self, class_type, rec_obj):
         """Populate class instance with data from record."""
         fields = [op(field) for field in attr.fields(class_type)]
@@ -169,15 +126,33 @@ class Collection(BaseRecord):
     def post_items(self, client):
         """Post items to collection."""
         for item in self.items:
-            item_uuid, item_handle = client.post_item_to_collection(self.uuid, item)
+            item_uuid, item_handle = item.post_to_collection(client, self.uuid, item)
             item.uuid = item_uuid
             item.handle = item_handle
             logger.info(f"Item posted: {item_uuid}")
             for bitstream in item.bitstreams:
-                bitstream_uuid = client.post_bitstream(item_uuid, bitstream)
+                bitstream_uuid = bitstream.post_bitstream(client, item_uuid, bitstream)
                 bitstream.uuid = bitstream_uuid
                 logger.info(f"Bitstream posted: {bitstream_uuid}")
             yield item
+
+    def post_to_community(self, client, community_handle, coll_name):
+        """Post a collection to a specified community."""
+        hdl_endpoint = f"{client.url}/handle/{community_handle}"
+        community = requests.get(
+            hdl_endpoint, headers=client.header, cookies=client.cookies
+        ).json()
+        community_uuid = community["uuid"]
+        uuid_endpoint = f"{client.url}/communities/{community_uuid}/collections"
+        coll_uuid = requests.post(
+            uuid_endpoint,
+            headers=client.header,
+            cookies=client.cookies,
+            json={"name": coll_name},
+        ).json()
+        coll_uuid = coll_uuid["uuid"]
+        logger.info(f"Collection posted: {coll_uuid}")
+        return coll_uuid
 
     @classmethod
     def create_metadata_for_items_from_csv(cls, csv_reader, field_map):
@@ -249,6 +224,19 @@ class Item(BaseRecord):
             source_system_identifier=source_system_identifier,
         )
 
+    def post_to_collection(self, client, collection_uuid, item):
+        """Post item to a specified collection and return the item ID."""
+        endpoint = f"{client.url}/collections/{collection_uuid}/items"
+        post_response = requests.post(
+            endpoint,
+            headers=client.header,
+            cookies=client.cookies,
+            json={"metadata": attr.asdict(item)["metadata"]},
+        ).json()
+        item_uuid = post_response["uuid"]
+        item_handle = post_response["handle"]
+        return item_uuid, item_handle
+
 
 @attr.s
 class Bitstream(BaseRecord):
@@ -262,6 +250,20 @@ class Bitstream(BaseRecord):
             endpoint, headers=client.header, cookies=client.cookies
         )
         return response.status_code
+
+    def post_bitstream(self, client, item_uuid, bitstream):
+        """Post a bitstream to a specified item and return the bitstream
+        ID."""
+        endpoint = (
+            f"{client.url}/items/{item_uuid}" f"/bitstreams?name={bitstream.name}"
+        )
+        header_upload = {"accept": "application/json"}
+        data = open(bitstream.file_path, "rb")
+        response = requests.post(
+            endpoint, headers=header_upload, cookies=client.cookies, data=data
+        ).json()
+        bitstream.uuid = response["uuid"]
+        return bitstream.uuid
 
 
 @attr.s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,8 +81,8 @@ def web_mock():
         m.post("mock://example.com/login", cookies=cookies)
         user_json = {"fullname": "User Name"}
         m.get("mock://example.com/status", json=user_json)
-        rec_json = {"metadata": {"title": "Sample title"}, "type": "item"}
-        m.get("mock://example.com/items/123?expand=all", json=rec_json)
+        item_metadata_json = {"metadata": {"title": "Sample title"}, "type": "item"}
+        m.get("mock://example.com/items/123?expand=all", json=item_metadata_json)
         results_json1 = {"items": [{"link": "1234"}]}
         results_json2 = {"items": []}
         m.get(
@@ -91,19 +91,20 @@ def web_mock():
         )
         rec_json = {"uuid": "a1b2"}
         m.get("mock://example.com/handle/111.1111", json=rec_json)
-        coll_json = {"uuid": "c3d4"}
-        m.post("mock://example.com/communities/a1b2/collections", json=coll_json)
+        collection_json = {"uuid": "c3d4"}
+        m.post("mock://example.com/communities/a1b2/collections", json=collection_json)
         item_json = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/c3d4/items", json=item_json)
-        b_json_1 = {"uuid": "g7h8"}
+        bitstream_json_1 = {"uuid": "g7h8"}
         url_1 = "mock://example.com/items/e5f6/bitstreams?name=test_01.pdf"
-        m.post(url_1, json=b_json_1)
-        b_json_2 = {"uuid": "i9j0"}
+        m.post(url_1, json=bitstream_json_1)
+        bitstream_json_2 = {"uuid": "i9j0"}
         url_2 = "mock://example.com/items/e5f6/bitstreams?name=test_02.pdf"
-        m.post(url_2, json=b_json_2)
+        m.post(url_2, json=bitstream_json_2)
         m.get("mock://remoteserver.com/files/test_01.pdf", content=b"Sample")
-        coll_json = {"uuid": "k1l2"}
-        m.get("mock://example.com/handle/333.3333", json=coll_json)
+        collection_json = {"uuid": "k1l2"}
+        m.get("mock://example.com/handle/333.3333", json=collection_json)
         item_json_2 = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/k1l2/items", json=item_json_2)
+        m.delete("mock://example.com/items/g7h8", status_code=200)
         yield m

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ def input_dir(tmp_path):
         pass
     with open(f"{input_dir}/test_01.jpg", "w"):
         pass
+    with open(f"{input_dir}/tast_01.jpg", "w"):
+        pass
     return str(f"{input_dir}/")
 
 
@@ -91,21 +93,40 @@ def web_mock():
         )
         rec_json = {"uuid": "a1b2"}
         m.get("mock://example.com/handle/111.1111", json=rec_json)
-        collection_json = {"uuid": "c3d4"}
+        community_json = {
+            "uuid": "a1b2",
+            "name": "Community title",
+            "type": "community",
+            "collections": [],
+        }
+        m.get("mock://example.com/communities/a1b2?expand=all", json=community_json)
+        collection_json = {
+            "uuid": "c3d4",
+            "name": "Collection title",
+            "type": "collection",
+            "items": [],
+        }
         m.post("mock://example.com/communities/a1b2/collections", json=collection_json)
+        m.get("mock://example.com/collections/c3d4?expand=all", json=collection_json)
         item_json = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/c3d4/items", json=item_json)
         bitstream_json_1 = {"uuid": "g7h8"}
-        url_1 = "mock://example.com/items/e5f6/bitstreams?name=test_01.pdf"
-        m.post(url_1, json=bitstream_json_1)
+        bitstream_url_1 = "mock://example.com/items/e5f6/bitstreams?name=test_01.pdf"
+        m.post(bitstream_url_1, json=bitstream_json_1)
         bitstream_json_2 = {"uuid": "i9j0"}
-        url_2 = "mock://example.com/items/e5f6/bitstreams?name=test_02.pdf"
-        m.post(url_2, json=bitstream_json_2)
+        bitstream_url_2 = "mock://example.com/items/e5f6/bitstreams?name=test_02.pdf"
+        m.post(bitstream_url_2, json=bitstream_json_2)
+        bitstream_json_3 = {"uuid": "q7r8"}
+        bitstream_url_3 = "mock://example.com/items/e5f6/bitstreams?name=tast_01.jpg"
+        m.post(bitstream_url_3, json=bitstream_json_3)
+        bitstream_json_4 = {"uuid": "s9t0"}
+        bitstream_url_4 = "mock://example.com/items/e5f6/bitstreams?name=test_01.jpg"
+        m.post(bitstream_url_4, json=bitstream_json_4)
         m.get("mock://remoteserver.com/files/test_01.pdf", content=b"Sample")
-        collection_json = {"uuid": "k1l2"}
         m.get("mock://example.com/handle/333.3333", json=collection_json)
         item_json_2 = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/k1l2/items", json=item_json_2)
         m.delete("mock://example.com/items/m3n4", status_code=200)
         m.delete("mock://example.com/bitstreams/o5p6", status_code=200)
+        m.get("mock://example.com/registries/schema/dc?expand=all", json={})
         yield m

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,20 @@ def aspace_mapping():
 
 
 @pytest.fixture()
+def mapping_no_file_identifier():
+    with open("tests/fixtures/mapping_no_file_identifier.json") as f:
+        mapping = json.load(f)
+        yield mapping
+
+
+@pytest.fixture()
+def mapping_no_source_system_identifier():
+    with open("tests/fixtures/mapping_no_source_system_identifier.json") as f:
+        mapping = json.load(f)
+        yield mapping
+
+
+@pytest.fixture()
 def output_dir(tmp_path):
     output_dir = tmp_path / "output"
     output_dir.mkdir()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,5 +106,6 @@ def web_mock():
         m.get("mock://example.com/handle/333.3333", json=collection_json)
         item_json_2 = {"uuid": "e5f6", "handle": "222.2222"}
         m.post("mock://example.com/collections/k1l2/items", json=item_json_2)
-        m.delete("mock://example.com/items/g7h8", status_code=200)
+        m.delete("mock://example.com/items/m3n4", status_code=200)
+        m.delete("mock://example.com/bitstreams/o5p6", status_code=200)
         yield m

--- a/tests/fixtures/mapping_no_file_identifier.json
+++ b/tests/fixtures/mapping_no_file_identifier.json
@@ -1,0 +1,32 @@
+{
+  "dc.title": {
+    "csv_field_name": "title",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "source_system_identifier": {
+    "csv_field_name": "uri",
+    "language": null,
+    "delimiter": ""
+  },
+  "dc.contributor.author": {
+    "csv_field_name": "author",
+    "language": null,
+    "delimiter": "|"
+  },
+  "dc.description": {
+    "csv_field_name": "description",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights": {
+    "csv_field_name": "rights_statement",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights.uri": {
+    "csv_field_name": "rights_uri",
+    "language": null,
+    "delimiter": ""
+  }
+}

--- a/tests/fixtures/mapping_no_source_system_identifier.json
+++ b/tests/fixtures/mapping_no_source_system_identifier.json
@@ -1,0 +1,32 @@
+{
+  "file_identifier": {
+    "csv_field_name": "file_identifier",
+    "language": null,
+    "delimiter": ""
+  },
+  "dc.title": {
+    "csv_field_name": "title",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.contributor.author": {
+    "csv_field_name": "author",
+    "language": null,
+    "delimiter": "|"
+  },
+  "dc.description": {
+    "csv_field_name": "description",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights": {
+    "csv_field_name": "rights_statement",
+    "language": "en_US",
+    "delimiter": ""
+  },
+  "dc.rights.uri": {
+    "csv_field_name": "rights_uri",
+    "language": null,
+    "delimiter": ""
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,7 @@
 from dsaps.cli import main
 
 
-def test_additems(runner, input_dir):
-    """Test adding items to a collection."""
+def test_additems_existing_collection(runner, input_dir):
     result = runner.invoke(
         main,
         [
@@ -26,6 +25,65 @@ def test_additems(runner, input_dir):
         ],
     )
     assert result.exit_code == 0
+
+
+def test_additems_ingest_report(runner, input_dir, output_dir):
+    result = runner.invoke(
+        main,
+        [
+            "--url",
+            "mock://example.com/",
+            "--email",
+            "test@test.mock",
+            "--password",
+            "1234",
+            "additems",
+            "--metadata-csv",
+            "tests/fixtures/aspace_metadata_delimited.csv",
+            "--field-map",
+            "config/aspace_mapping.json",
+            "--content-directory",
+            input_dir,
+            "--file-type",
+            "pdf",
+            "--collection-handle",
+            "333.3333",
+            "--ingest-report",
+            "--output-directory",
+            output_dir,
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_additems_missing_required_options(runner, input_dir):
+    result = runner.invoke(
+        main,
+        [
+            "--url",
+            "mock://example.com/",
+            "--email",
+            "test@test.mock",
+            "--password",
+            "1234",
+            "additems",
+            "--metadata-csv",
+            "tests/fixtures/aspace_metadata_delimited.csv",
+            "--field-map",
+            "config/aspace_mapping.json",
+            "--content-directory",
+            input_dir,
+            "--file-type",
+            "pdf",
+        ],
+    )
+    assert result.exit_code == 2
+    assert (
+        "collection_handle option must be used or additems must be run after"
+    ) in result.output
+
+
+def test_additems_new_collection(runner, input_dir):
     result = runner.invoke(
         main,
         [
@@ -54,8 +112,7 @@ def test_additems(runner, input_dir):
     assert result.exit_code == 0
 
 
-def test_newcollection(runner, input_dir):
-    """Test newcoll command."""
+def test_newcollection(client, runner, input_dir):
     result = runner.invoke(
         main,
         [
@@ -76,7 +133,6 @@ def test_newcollection(runner, input_dir):
 
 
 def test_reconcile(runner, input_dir, output_dir):
-    """Test reconcile command."""
     result = runner.invoke(
         main,
         [
@@ -98,3 +154,28 @@ def test_reconcile(runner, input_dir, output_dir):
         ],
     )
     assert result.exit_code == 0
+
+
+def test_reconcile_bad_output_directory(runner, input_dir, output_dir):
+    result = runner.invoke(
+        main,
+        [
+            "--url",
+            "mock://example.com/",
+            "--email",
+            "test@test.mock",
+            "--password",
+            "1234",
+            "reconcile",
+            "--metadata-csv",
+            "tests/fixtures/aspace_metadata_delimited.csv",
+            "--output-directory",
+            "tests",
+            "--content-directory",
+            input_dir,
+            "--file-type",
+            "pdf",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Include / at the end of the path." in result.output

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -25,7 +25,7 @@ def test_create_ingest_report(runner, output_dir):
     """Test create_ingest_report function."""
     file_name = "ingest_report.csv"
     items = [Item(source_system_identifier="/repo/0/ao/123", handle="111.1111")]
-    helpers.create_ingest_report(items, f"{output_dir}{file_name}")
+    helpers.create_ingest_report(items, f"{file_name}", output_dir)
     with open(f"{output_dir}{file_name}") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,25 +35,16 @@ def test_get_record(client):
     assert attr.asdict(rec_obj)["metadata"] == {"title": "Sample title"}
 
 
-def test_post_bitstream(client, input_dir):
-    """Test post_bitstream method."""
-    item_uuid = "e5f6"
-    bitstream = models.Bitstream(
-        name="test_01.pdf", file_path=f"{input_dir}test_01.pdf"
-    )
-    bit_uuid = client.post_bitstream(item_uuid, bitstream)
-    assert bit_uuid == "g7h8"
-
-
-def test_post_coll_to_comm(client):
-    """Test post_coll_to_comm method."""
-    comm_handle = "111.1111"
+def test_collection_post_to_community(client):
+    """Test post_coll_to_community method."""
+    collection = models.Collection()
+    community_handle = "111.1111"
     coll_name = "Test Collection"
-    coll_uuid = client.post_coll_to_comm(comm_handle, coll_name)
+    coll_uuid = collection.post_to_community(client, community_handle, coll_name)
     assert coll_uuid == "c3d4"
 
 
-def test_post_item_to_collection(client, input_dir):
+def test_item_post_to_collection(client, input_dir):
     """Test post_item_to_collection method."""
     item = models.Item()
     item.bitstreams = [
@@ -67,7 +58,7 @@ def test_post_item_to_collection(client, input_dir):
         models.MetadataEntry(key="dc.relation.isversionof", value="repo/0/ao/123"),
     ]
     coll_uuid = "c3d4"
-    item_uuid, item_handle = client.post_item_to_collection(coll_uuid, item)
+    item_uuid, item_handle = item.post_to_collection(client, coll_uuid, item)
     assert item_uuid == "e5f6"
     assert item_handle == "222.2222"
 
@@ -189,3 +180,13 @@ def test_bitstream_delete(client):
     bitstream = models.Bitstream(uuid="o5p6")
     response = bitstream.delete(client)
     assert response == 200
+
+
+def test_bitstream_post_to_item(client, input_dir):
+    """Test post_bitstream method."""
+    item_uuid = "e5f6"
+    bitstream = models.Bitstream(
+        name="test_01.pdf", file_path=f"{input_dir}test_01.pdf"
+    )
+    bit_uuid = bitstream.post_bitstream(client, item_uuid, bitstream)
+    assert bit_uuid == "g7h8"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,9 +122,49 @@ def test_item_bitstreams_in_directory(input_dir):
     assert item.bitstreams[1].name == "test_02.pdf"
 
 
-def test_item_metadata_from_csv_row(aspace_delimited_csv, aspace_mapping):
+def test_item_metadata_from_csv_row_aspace_mapping(
+    aspace_delimited_csv, aspace_mapping
+):
     row = next(aspace_delimited_csv)
     item = models.Item.metadata_from_csv_row(row, aspace_mapping)
+    assert attr.asdict(item)["metadata"] == [
+        {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
+        {"key": "dc.contributor.author", "value": "Smith, John", "language": None},
+        {"key": "dc.contributor.author", "value": "Smith, Jane", "language": None},
+        {
+            "key": "dc.description",
+            "value": "More info at /repo/0/ao/456",
+            "language": "en_US",
+        },
+        {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
+        {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
+    ]
+
+
+def test_item_metadata_from_csv_row_no_file_identifier(
+    aspace_delimited_csv, mapping_no_file_identifier
+):
+    row = next(aspace_delimited_csv)
+    item = models.Item.metadata_from_csv_row(row, mapping_no_file_identifier)
+    assert attr.asdict(item)["metadata"] == [
+        {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
+        {"key": "dc.contributor.author", "value": "Smith, John", "language": None},
+        {"key": "dc.contributor.author", "value": "Smith, Jane", "language": None},
+        {
+            "key": "dc.description",
+            "value": "More info at /repo/0/ao/456",
+            "language": "en_US",
+        },
+        {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
+        {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
+    ]
+
+
+def test_item_metadata_from_csv_row_no_source_system_identifier(
+    aspace_delimited_csv, mapping_no_source_system_identifier
+):
+    row = next(aspace_delimited_csv)
+    item = models.Item.metadata_from_csv_row(row, mapping_no_source_system_identifier)
     assert attr.asdict(item)["metadata"] == [
         {"key": "dc.title", "value": "Tast Item", "language": "en_US"},
         {"key": "dc.contributor.author", "value": "Smith, John", "language": None},

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,12 @@ def test_authenticate(client):
     assert client.cookies == {"JSESSIONID": "11111111"}
 
 
+def test_delete_record(client):
+    """Test delete_record method."""
+    response = client.delete_record("g7h8", "items")
+    assert response == 200
+
+
 def test_filtered_item_search(client):
     """Test filtered_item_search method."""
     key = "dc.title"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,12 +12,6 @@ def test_authenticate(client):
     assert client.cookies == {"JSESSIONID": "11111111"}
 
 
-def test_delete_record(client):
-    """Test delete_record method."""
-    response = client.delete_record("g7h8", "items")
-    assert response == 200
-
-
 def test_filtered_item_search(client):
     """Test filtered_item_search method."""
     key = "dc.title"
@@ -115,6 +109,12 @@ def test_collection_post_items(client, input_dir, aspace_delimited_csv, aspace_m
         assert item.uuid == "e5f6"
 
 
+def test_item_delete(client):
+    item = models.Item(uuid="m3n4")
+    response = item.delete(client)
+    assert response == 200
+
+
 def test_item_bitstreams_in_directory(input_dir):
     item = models.Item(file_identifier="test")
     item.bitstreams_in_directory(input_dir)
@@ -183,3 +183,9 @@ def test_item_metadata_from_csv_row_no_source_system_identifier(
         {"key": "dc.rights", "value": "Totally Free", "language": "en_US"},
         {"key": "dc.rights.uri", "value": "http://free.gov", "language": None},
     ]
+
+
+def test_bitstream_delete(client):
+    bitstream = models.Bitstream(uuid="o5p6")
+    response = bitstream.delete(client)
+    assert response == 200


### PR DESCRIPTION
Draft, will rebase after #30 is merged

#### What does this PR do?
* Add unit tests for other `get_record` use cases
* Add CLI tests for different scenarios
* Add `output directory` option for `add_items` CLI command and update tests and docs
* Update `create_ingest_report` function to include `output_directory`
* Expand mock responses for new tests
* Remove test docstrings and misc docstring changes in `cli.py`
* Reorder `Client` class methods in `models.py`

#### How can a reviewer manually see the effects of these changes?
Verify that unit tests still pass when running `pipenv run pytest`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ETD-404

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
